### PR TITLE
Change Whonix installer name

### DIFF
--- a/MakeInstaller.bat
+++ b/MakeInstaller.bat
@@ -9,4 +9,4 @@ endlocal
 ))>"location.bat"
 call location.bat
 7za a Installer ./Output/
-copy /b 7zSD.sfx + config.txt + Installer.7z "Install Whonix.exe"
+copy /b 7zSD.sfx + config.txt + Installer.7z whonix-installer.exe


### PR DESCRIPTION
There are 2 other files that are created at build time `InstallWhonix.exe` and  `InstallWhonix-1` . Leaving these file names as they are (not changing to match new installer name) since it could cause confusion if someone builds from source and finds that these file names closely match the actual `whonix-installer.exe` 